### PR TITLE
Adicionado o campo opcional posterUrl ao modelo Item.

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Item{
   releaseYear Int
   type ITEM_TYPE
   metadata Json?
+  posterUrl String?
   reviews Review[]
 }
 


### PR DESCRIPTION
Introduz um novo campo opcional do tipo String, 'posterUrl', ao modelo Item no esquema Prisma para armazenar a URL da imagem do pôster de um item.