### PR TITLE
Incluir o ID do usuário na resposta da avaliação do item

### DIFF
--- a/server.js
+++ b/server.js
@@ -501,7 +501,7 @@ app.get('/item/:id', async (req, res)=>{
                     include:{
                         //Inclui o nome do usuário que fez a review
                         user:{
-                            select:{name: true}
+                            select:{id: true, name: true}
                         }
                     }
                 }
@@ -529,7 +529,10 @@ app.get('/item/:id', async (req, res)=>{
                 rating: review.rating,
                 text: review.text,
                 createdAt: review.createdAt,
-                userName: review.user.name, // Pega o nome do usuário aninhado
+                author: {
+                  id: review.user.id, // Garante que o ID do usuário está presente
+                  fullName: review.user.name, // Mapeia para o nome do Prisma
+                }
             }))
         };
         // Retorna os detalhes do item formatado


### PR DESCRIPTION
A resposta da review agora inclui tanto o ID do usuário quanto o nome de cada autor da review, melhorando a consistência dos dados e permitindo uma melhor identificação dos autores.